### PR TITLE
Defer bot settings validation to runtime and proxy core config

### DIFF
--- a/app/bot/settings.py
+++ b/app/bot/settings.py
@@ -1,38 +1,8 @@
-import os
-from dataclasses import dataclass
-from typing import List
-from dotenv import load_dotenv
+from app.core.config import Settings, settings as core_settings
 
-load_dotenv()
-
-@dataclass
-class Settings:
-    bot_token: str
-    admin_ids: List[int]
-    log_level: str
-    default_ca: str | None
 
 def load_settings() -> Settings:
-    token = os.getenv("BOT_TOKEN", "").strip()
-    if not token:
-        raise RuntimeError("BOT_TOKEN is required in environment")
+    return core_settings
 
-    admin_ids_raw = os.getenv("ADMIN_IDS", "").strip()
-    if not admin_ids_raw:
-        raise RuntimeError("ADMIN_IDS (comma-separated) is required")
-
-    admin_ids = []
-    for part in admin_ids_raw.split(","):
-        part = part.strip()
-        if not part:
-            continue
-        admin_ids.append(int(part))
-
-    return Settings(
-        bot_token=token,
-        admin_ids=admin_ids,
-        log_level=os.getenv("LOG_LEVEL", "INFO").upper(),
-        default_ca=os.getenv("DEFAULT_CA") or None,
-    )
 
 SETTINGS = load_settings()


### PR DESCRIPTION
## Summary
- Proxy `app.bot.settings` to use core configuration object
- Validate token and admin IDs at runtime when not in dry mode

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e26c92cc83328b07269e0d76df88