### PR TITLE
Refactor logger to use environment configuration

### DIFF
--- a/app/core/client.py
+++ b/app/core/client.py
@@ -20,7 +20,7 @@ from solders.solders import SimulateTransactionResp, AccountJSON, Account
 from solders.transaction import Transaction
 from solders.system_program import transfer, TransferParams
 
-from .logger import logger
+from app.core.logger import logger
 
 class AsyncRateLimiter:
     def __init__(self, max_calls: int, per_seconds: float):

--- a/app/core/logger.py
+++ b/app/core/logger.py
@@ -1,15 +1,17 @@
+import os
 import sys
 import structlog
 from loguru import logger as loguru_logger
-from .config import settings
 
 
-def setup_logger(service_name: str, level: str = settings.log_level):
+def setup_logger(service_name: str):
     """
     Configures a non-blocking async-friendly logger using structlog + loguru.
     """
 
     import logging
+
+    level = os.getenv("LOG_LEVEL", "INFO")
     logging.basicConfig(level=level.upper())
 
     loguru_logger.remove()
@@ -39,5 +41,6 @@ def setup_logger(service_name: str, level: str = settings.log_level):
     )
 
     return structlog.get_logger(service=service_name)
+
 
 logger = setup_logger("bundle_bot")


### PR DESCRIPTION
## Summary
- remove dependency on settings module in logger
- read log level from LOG_LEVEL environment variable
- export initialized `logger` and update client import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1e40ed6dc83328600556b66288c0d