### PR TITLE
Add persistent contract address storage

### DIFF
--- a/app/bot/facade.py
+++ b/app/bot/facade.py
@@ -17,6 +17,7 @@ from app.core.wallet_manager import WalletManager     # у тебя этот к�
 from app.core.client import SolanaClient     # как в твоих модулях
 
 from .config import AppConfig, save_config
+from .storage import load_contracts, save_contracts
 from .logs import TelegramLogHandler
 
 
@@ -160,9 +161,13 @@ class BabloController:
             await self._send(f"🟠 <b>Alert</b>\n<pre>{safe}</pre>")
 
         async def get_ca() -> str:
-            ca = self.cfg.bablo.last_ca
-            if not ca:
+            contracts = load_contracts()
+            if not contracts:
                 raise RuntimeError("CA не задан. Используй /set_ca <MINT>")
+            ca = contracts.pop(0)
+            save_contracts(contracts)
+            self.cfg.bablo.last_ca = ca
+            save_config(self.cfg)
             return ca
 
         b = Bablo(
@@ -191,9 +196,13 @@ class BabloController:
 
     # ---------- Public API ----------
     async def set_ca(self, ca: str):
-        self.cfg.bablo.last_ca = ca.strip()
+        clean = ca.strip()
+        contracts = load_contracts()
+        contracts.append(clean)
+        save_contracts(contracts)
+        self.cfg.bablo.last_ca = clean
         save_config(self.cfg)
-        await self._send(f"📌 Установлен CA: <code>{escape(self.cfg.bablo.last_ca)}</code>")
+        await self._send(f"📌 Добавлен CA: <code>{escape(clean)}</code>")
 
     async def set_param(self, key: str, value: str):
         bcfg = self.cfg.bablo

--- a/app/bot/handlers/contracts.py
+++ b/app/bot/handlers/contracts.py
@@ -28,7 +28,7 @@ async def receive_ca(message: types.Message, state: FSMContext) -> None:
     if controller and hasattr(controller, "set_ca"):
         try:
             await maybe_await(controller.set_ca(ca))
-            await message.reply(f"CA set to <code>{ca}</code> via controller.set_ca()", parse_mode="HTML")
+            await message.reply(f"CA stored: <code>{ca}</code>", parse_mode="HTML")
             await state.clear()
             return
         except Exception as e:

--- a/app/bot/storage.py
+++ b/app/bot/storage.py
@@ -1,9 +1,51 @@
+"""Utilities for bot storage.
+
+This module serves two purposes:
+
+1. Provide FSM states and admin checks used by the bot handlers.
+2. Persist a list of contract addresses so they survive bot restarts.
+
+The path to the file used for storing contracts is configurable via the
+``CONTRACTS_STORAGE_PATH`` environment variable.
+"""
+
+from pathlib import Path
+from typing import List
+import os
+
 from aiogram.fsm.state import StatesGroup, State
 
 try:
     from .settings import SETTINGS
 except Exception:  # pragma: no cover - SETTINGS may be optional during tests
     SETTINGS = None
+
+
+# --------- Contracts storage utilities ---------
+
+CONTRACTS_STORAGE_PATH = Path(os.getenv("CONTRACTS_STORAGE_PATH", "contracts.txt"))
+
+
+def load_contracts() -> List[str]:
+    """Load list of contract addresses from ``CONTRACTS_STORAGE_PATH``.
+
+    Returns an empty list if the file does not exist.
+    """
+
+    if not CONTRACTS_STORAGE_PATH.exists():
+        return []
+
+    with CONTRACTS_STORAGE_PATH.open("r", encoding="utf-8") as fh:
+        return [line.strip() for line in fh if line.strip()]
+
+
+def save_contracts(contracts: List[str]) -> None:
+    """Persist list of contract addresses to ``CONTRACTS_STORAGE_PATH``."""
+
+    CONTRACTS_STORAGE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with CONTRACTS_STORAGE_PATH.open("w", encoding="utf-8") as fh:
+        for ca in contracts:
+            fh.write(ca.strip() + "\n")
 
 
 class EditState(StatesGroup):


### PR DESCRIPTION
## Summary
- add load_contracts/save_contracts helpers with CONTRACTS_STORAGE_PATH
- persist received CAs and read them when Bablo requests next contract
- tweak contract handler message to reflect storing behavior

## Testing
- `pytest`
- `python -m py_compile app/bot/storage.py app/bot/facade.py app/bot/handlers/contracts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2c4bf1fc48332b59c7cbccaa2b53d