### PR TITLE
feat: add error log handler

### DIFF
--- a/app/bot/logs.py
+++ b/app/bot/logs.py
@@ -33,3 +33,54 @@ class TelegramLogHandler(logging.Handler):
     @staticmethod
     def _clip(s: str, limit: int = 3500) -> str:
         return s if len(s) <= limit else s[:limit] + " …"
+
+
+class TelegramErrorHandler(logging.Handler):
+    """Хэндлер, отправляющий сообщения уровня ERROR и выше в Telegram.
+
+    Сообщения группируются, чтобы уменьшить спам: все записи,
+    пришедшие за короткий промежуток времени, объединяются в одно
+    Telegram-сообщение.
+    """
+
+    def __init__(
+        self,
+        send_fn: Callable[[int, str], "asyncio.Future"],
+        chat_id: int,
+        level: int = logging.ERROR,
+        group_delay: float = 0.5,
+    ) -> None:
+        super().__init__(level=level)
+        self.send_fn = send_fn
+        self.chat_id = chat_id
+        self.group_delay = group_delay
+        self._lock = asyncio.Lock()
+        self._buf: list[str] = []
+        self._task: asyncio.Task | None = None
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - async fire-and-forget
+        if record.levelno < self.level:
+            return
+        try:
+            msg = self.format(record)
+        except Exception:
+            return
+        self._buf.append(msg)
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._flush())
+
+    async def _flush(self) -> None:
+        await asyncio.sleep(self.group_delay)
+        async with self._lock:
+            if not self._buf:
+                return
+            text = "\n".join(self._clip(m) for m in self._buf)
+            self._buf.clear()
+            try:
+                await self.send_fn(self.chat_id, f"<code>{text}</code>")
+            except Exception:
+                pass
+
+    @staticmethod
+    def _clip(s: str, limit: int = 3500) -> str:
+        return s if len(s) <= limit else s[:limit] + " …"


### PR DESCRIPTION
## Summary
- add TelegramErrorHandler that groups error-level logs and filters out lower levels
- stop bot_on_status from sending status updates to the chat
- wire error handler into app.core logger for Telegram notifications

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b2c5d13bc48332b8a31fe74db07214