### PR TITLE
Add CLI run_mode arg and delegate bot runner

### DIFF
--- a/app/bot/runner.py
+++ b/app/bot/runner.py
@@ -1,6 +1,9 @@
 from aiogram import Bot, Dispatcher
 
 from .handlers import routers
+from .config import load_config
+from .facade import BabloController
+from .settings import SETTINGS
 
 
 def create_dispatcher() -> Dispatcher:
@@ -11,7 +14,18 @@ def create_dispatcher() -> Dispatcher:
     return dp
 
 
-async def run(bot: Bot) -> None:
+async def run() -> None:
     """Запустить бота."""
+    if not SETTINGS.bot_token:
+        raise RuntimeError("BOT_TOKEN not provided in env")
+
+    bot = Bot(token=SETTINGS.bot_token, parse_mode=None)
     dp = create_dispatcher()
+
+    cfg = load_config()
+    admin_ids = getattr(SETTINGS, "admin_ids", [])
+    admin_id = admin_ids[0] if admin_ids else None
+    controller = BabloController(cfg, bot, admin_id)
+    bot["controller"] = controller
+
     await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- Add `--run_mode` CLI argument to main entry point, prioritizing command line over env
- Remove inlined Telegram bot runner from main and delegate to `app.bot.runner.run`
- Extend bot runner to build bot/controller from settings and start polling

## Testing
- `python -m py_compile app/main.py app/bot/runner.py`
- `python app/main.py --help` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -q -r reqs.txt` *(fails: Could not find a version that satisfies the requirement aiofiles==24.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cdf15da48332bd42b6f3c8e12e29