### PR TITLE
Notify chat on bot startup

### DIFF
--- a/app/bot/runner.py
+++ b/app/bot/runner.py
@@ -1,8 +1,11 @@
+import os
+
 from aiogram import Bot, Dispatcher
 
 from .handlers import routers
 from .config import load_config
 from .facade import BabloController
+from .keyboards import main_menu_kb
 from .settings import SETTINGS
 
 
@@ -27,5 +30,9 @@ async def run() -> None:
     admin_id = admin_ids[0] if admin_ids else None
     controller = BabloController(cfg, bot, admin_id)
     bot["controller"] = controller
+    boot_chat_id = os.getenv("TELEGRAM_BOOT_CHAT_ID") or admin_id
+    if boot_chat_id:
+        await bot.send_message(boot_chat_id, "✅ Bot up (mode=bot)")
+        await bot.send_message(boot_chat_id, "Меню настроек", reply_markup=main_menu_kb())
 
     await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- Send startup notification and main menu when bot launches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2cf77e37c8332a0a849a6c4503d51