### PR TITLE
Add missing Command filter import

### DIFF
--- a/app/bot/handlers/control.py
+++ b/app/bot/handlers/control.py
@@ -1,4 +1,5 @@
 from aiogram import Router, types, F
+from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 
 from ..keyboards import main_menu_kb


### PR DESCRIPTION
## Summary
- import Command filter in control handler to match usage pattern

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2d17e641483329c486f64e5a7d87d