### PR TITLE
Refactor controller access to attributes

### DIFF
--- a/app/bot/handlers/contracts.py
+++ b/app/bot/handlers/contracts.py
@@ -24,7 +24,7 @@ async def receive_ca(message: types.Message, state: FSMContext) -> None:
         await state.clear()
         return
     ca = message.text.strip()
-    controller = message.bot.get("controller")
+    controller = getattr(message.bot, "controller", None)
     if controller and hasattr(controller, "set_ca"):
         try:
             await maybe_await(controller.set_ca(ca))

--- a/app/bot/handlers/control.py
+++ b/app/bot/handlers/control.py
@@ -14,7 +14,7 @@ async def action_run(query: types.CallbackQuery) -> None:
     if not admin_check(query.from_user.id):
         await query.answer("Access denied.", show_alert=True)
         return
-    controller = query.bot.get("controller")
+    controller = getattr(query.bot, "controller", None)
     if controller and hasattr(controller, "start"):
         await maybe_await(controller.start())
         await query.message.reply("Controller.start() called.")
@@ -28,7 +28,7 @@ async def action_stop(query: types.CallbackQuery) -> None:
     if not admin_check(query.from_user.id):
         await query.answer("Access denied.", show_alert=True)
         return
-    controller = query.bot.get("controller")
+    controller = getattr(query.bot, "controller", None)
     if controller and hasattr(controller, "stop"):
         await maybe_await(controller.stop())
         await query.message.reply("Controller.stop() called.")
@@ -42,7 +42,7 @@ async def action_toggle_autorun(query: types.CallbackQuery) -> None:
     if not admin_check(query.from_user.id):
         await query.answer("Access denied.", show_alert=True)
         return
-    controller = query.bot.get("controller")
+    controller = getattr(query.bot, "controller", None)
     if controller and hasattr(controller, "cfg"):
         cfg = controller.cfg
         autorun = getattr(cfg, "autorun", False)
@@ -71,7 +71,7 @@ async def cmd_run(message: types.Message) -> None:
     if not admin_check(message.from_user.id):
         await message.reply("Access denied.")
         return
-    controller = message.bot.get("controller")
+    controller = getattr(message.bot, "controller", None)
     if controller and hasattr(controller, "start"):
         await maybe_await(controller.start())
         await message.reply("Run requested.")
@@ -84,7 +84,7 @@ async def cmd_stop(message: types.Message) -> None:
     if not admin_check(message.from_user.id):
         await message.reply("Access denied.")
         return
-    controller = message.bot.get("controller")
+    controller = getattr(message.bot, "controller", None)
     if controller and hasattr(controller, "stop"):
         await maybe_await(controller.stop())
         await message.reply("Stop requested.")

--- a/app/bot/handlers/settings.py
+++ b/app/bot/handlers/settings.py
@@ -40,7 +40,7 @@ async def receive_param_value(message: types.Message, state: FSMContext) -> None
         return
     data = await state.get_data()
     key = data.get("param_key")
-    controller = message.bot.get("controller")
+    controller = getattr(message.bot, "controller", None)
     success, msg = await _apply_config(controller, key, message.text)
     await message.reply(msg, parse_mode="HTML")
     await state.clear()

--- a/app/bot/handlers/status.py
+++ b/app/bot/handlers/status.py
@@ -15,7 +15,7 @@ async def action_status(query: types.CallbackQuery) -> None:
     if not admin_check(query.from_user.id):
         await query.answer("Access denied.", show_alert=True)
         return
-    controller = query.bot.get("controller")
+    controller = getattr(query.bot, "controller", None)
     if controller and hasattr(controller, "status"):
         try:
             st = await maybe_await(controller.status())
@@ -33,7 +33,7 @@ async def action_show_config(query: types.CallbackQuery) -> None:
     if not admin_check(query.from_user.id):
         await query.answer("Access denied.", show_alert=True)
         return
-    controller = query.bot.get("controller")
+    controller = getattr(query.bot, "controller", None)
     cfg = getattr(controller, "cfg", None)
     await query.message.reply(f"<b>Config:</b>\n<pre>{escape(str(cfg))}</pre>", parse_mode="HTML")
     await query.answer()
@@ -44,7 +44,7 @@ async def cmd_status(message: types.Message) -> None:
     if not admin_check(message.from_user.id):
         await message.reply("Access denied.")
         return
-    controller = message.bot.get("controller")
+    controller = getattr(message.bot, "controller", None)
     if controller and hasattr(controller, "status"):
         try:
             st = await maybe_await(controller.status())

--- a/app/bot/runner.py
+++ b/app/bot/runner.py
@@ -26,7 +26,8 @@ async def run() -> None:
     cfg = load_config()
     admin_id = SETTINGS.admin_ids[0] if SETTINGS.admin_ids else None
     controller = BabloController(cfg, bot, admin_id)
-    bot["controller"] = controller
+    bot.controller = controller
+    dp.controller = controller
     boot_chat_id = SETTINGS.boot_chat_id or admin_id
     if boot_chat_id:
         await bot.send_message(boot_chat_id, "✅ Bot up (mode=bot)")


### PR DESCRIPTION
## Summary
- store controller on bot and dispatcher via attributes
- use attribute-based controller lookup in handlers

## Testing
- `pytest -q`
- `python -m py_compile app/bot/runner.py app/bot/handlers/control.py app/bot/handlers/status.py app/bot/handlers/contracts.py app/bot/handlers/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2e4c5dd2083329f3ff56049264d56